### PR TITLE
opt(tidb): support setting graceful-wait-before-shutdown in config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ tidy: ## Run go mod tidy and verify the result
 ##@ Release
 
 docker-release:
-	docker buildx build --platform linux/amd64,linux/arm64 --push -t "$(DOCKER_REPO)/tidb-operator:$(IMAGE_TAG)" --build-arg "GOPROXY=$(shell go env GOPROXY)" --build-arg "LDFLAGS=$(LDFLAGS)" -f images/tidb-operator/Dockerfile.new .
+	docker buildx build --platform linux/amd64,linux/arm64 --push -t "$(DOCKER_REPO)/tidb-operator-internal:$(IMAGE_TAG)" --build-arg "GOPROXY=$(shell go env GOPROXY)" --build-arg "LDFLAGS=$(LDFLAGS)" -f images/tidb-operator/Dockerfile.new .
 
 .PHONY: check check-setup build e2e-build e2e gocovmerge test docker e2e-docker debug-build-docker
 

--- a/pkg/apis/pingcap/v1alpha1/tidb_config.go
+++ b/pkg/apis/pingcap/v1alpha1/tidb_config.go
@@ -157,6 +157,9 @@ type TiDBConfig struct {
 	// Labels are labels for TiDB server
 	// +optional
 	Labels map[string]string `toml:"labels,omitempty" json:"labels,omitempty"`
+	// GracefulWaitBeforeShutdown sets how long tidb should wait on shutdown before it closes its socket
+	// +optional
+	GracefulWaitBeforeShutdown *uint64 `toml:"graceful-wait-before-shutdown,omitempty" json:"graceful-wait-before-shutdown,omitempty"`
 }
 
 // Log is the log section of config.


### PR DESCRIPTION
### What problem does this PR solve?
Users can not set the graceful-wait-before-shutdown flag in tidb. This prevents a truely graceful restart of TiDB pods

### What is changed and how does it work?
Added the option to the TidbConfig struct. 

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
